### PR TITLE
Added redis service in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,6 +135,11 @@ services:
     ports:
       - "18130:18130"
 
+  redis:
+    image: redis:latest
+    ports:
+      - "6379:6379"
+
   lms:
     command: bash -c 'source /edx/app/edxapp/edxapp_env && while true; do python /edx/app/edxapp/edx-platform/manage.py lms runserver 0.0.0.0:18000 --settings devstack_docker; sleep 2; done'
     container_name: edx.devstack.lms
@@ -144,6 +149,7 @@ services:
       - mysql
       - memcached
       - mongo
+      - redis
     # Allows attachment to the LMS service using 'docker attach <containerID>'.
     stdin_open: true
     tty: true


### PR DESCRIPTION
**How to test ?**

- Open lms shell by running `make lms-shell` in devstack directory in terminal. 
- Go to  `/edx/app/edxapp` by running `cd ..` in lms shell.
- `vim lms.env.json`
- update `CELERY_BROKER_HOSTNAME` value with `redis://redis:6379/0`
- Add `"REDIS_HOST": "redis://redis:6379/0"` and `"REDIS_PORT": 6379`
- Now run provision if you haven't already run this. 
- Run `docker-compose -f docker-compose.yml -f docker-compose-host.yml up lms`
